### PR TITLE
fix(channel): use canonical channel id

### DIFF
--- a/src/youtube/parser.rs
+++ b/src/youtube/parser.rs
@@ -84,7 +84,7 @@ pub fn parse_contents(contents: Vec<Value>) -> Vec<ContentItem> {
 
 pub fn parse_channel_props(renderer: Value) -> Channel {
     Channel {
-        id: remove_quotes(renderer["channelId"].to_string()),
+        id: remove_quotes(renderer["subscriberCountText"]["simpleText"].to_string()),
         username: remove_quotes(renderer["title"]["simpleText"].to_string()),
         url: format!(
             "https://www.youtube.com{}",
@@ -138,7 +138,7 @@ pub fn parse_playlist_props(renderer: Value) -> Playlist {
         channel_id => PlaylistUploader::Channel(
             Channel {
                 id: remove_first_char(remove_quotes(channel_id.to_string())),
-                username: 
+                username:
                     remove_quotes(
                         renderer["metadata"]["lockupMetadataViewModel"]["metadata"]["contentMetadataViewModel"]["metadataRows"][0]["metadataParts"][0]["text"]["content"]
                             .to_string(),


### PR DESCRIPTION
## Description
Fixes the incorrect usage of channel identifiers. The app was using a non-canonical ID, which caused failures when fetching videos from the channels (resulting in 404 errors).

## Changes
- Replaced the incorrect ID with the **canonical channel ID**.

## Impact
- Channels can now be correctly resolved.
- Fixes the issue where video fetching failed with a 404 error.
